### PR TITLE
Update run_condor.py

### DIFF
--- a/test/run_condor.py
+++ b/test/run_condor.py
@@ -95,8 +95,8 @@ def main():
   if not (opt.ismc):
     year_list = ['UL2016_preVFPB','UL2016_preVFPC','UL2016_preVFPD','UL2016_preVFPE','UL2016_preVFPF','UL2016F','UL2016G','UL2016H','UL2017B','UL2017C','UL2017D','UL2017E','UL2017F','UL2018A','UL2018B','UL2018C','UL2018D']
     if opt.year in year_list : 
-      jmeCorrections  = createJMECorrector(opt.ismc,  dataYear=opt.year[:6], runPeriod=opt.year[6:],  jesUncert="Total", jetType="AK8PFPuppi",)
-      jetmetCorrector = createJMECorrector(opt.ismc,   dataYear=opt.year[:6], runPeriod=opt.year[6:], metBranchName="MET")
+      jmeCorrections  = createJMECorrector(opt.ismc,  dataYear=opt.year[:-1], runPeriod=opt.year[-1:],  jesUncert="Total", jetType="AK8PFPuppi",)
+      jetmetCorrector = createJMECorrector(opt.ismc,   dataYear=opt.year[:-1], runPeriod=opt.year[-1:], metBranchName="MET")
     if opt.year in ["UL2016_preVFPB","UL2016_preVFPC","UL2016_preVFPD","UL2016_preVFPE","UL2016_preVFPF"]:
       p = PostProcessor(opt.output, [opt.inputs], modules=[muonScaleRes2016a(),jetmetCorrector(),jmeCorrections(),VVV2016()], provenance=True,fwkJobReport=True, jsonInput=jsoninput)
 

--- a/test/run_condor.py
+++ b/test/run_condor.py
@@ -82,7 +82,7 @@ def main():
 
 
     if opt.year == "2016post":
-      p = PostProcessor(opt.output, opt.inputs.rstrip(",").split(","), modules=[countHistogramsModule(),puAutoWeight_2016(),PrefCorrUL16_postVFP(),muonIDISOSF2016post(),muonScaleRes2016b(),eleRECOSF2016post(),eleIDSF2016post(),jmeCorrections(),jetmetCorrector(),jetmetCorrector(),btagSFUL2016Post(),VVV2016(opt.MODE)], provenance=True,fwkJobReport=True, jsonInput=runsAndLumis(),outputbranchsel="keep_and_drop.txt")
+      p = PostProcessor(opt.output, opt.inputs.rstrip(",").split(","), modules=[countHistogramsModule(),puAutoWeight_2016(),PrefCorrUL16_postVFP(),muonIDISOSF2016post(),muonScaleRes2016b(),eleRECOSF2016post(),eleIDSF2016post(),jmeCorrections(),jetmetCorrector(),btagSFUL2016Post(),VVV2016(opt.MODE)], provenance=True,fwkJobReport=True, jsonInput=runsAndLumis(),outputbranchsel="keep_and_drop.txt")
     if opt.year == "2016pre":
       p = PostProcessor(opt.output, opt.inputs.rstrip(",").split(","), modules=[countHistogramsModule(),puAutoWeight_2016(),PrefCorrUL16_preVFP(),muonIDISOSF2016pre(),muonScaleRes2016a(),eleRECOSF2016pre(),eleIDSF2016pre(),jmeCorrections(),jetmetCorrector(),btagSFUL2016Pre(),VVV2016(opt.MODE)], provenance=True,fwkJobReport=True, jsonInput=runsAndLumis(),outputbranchsel="keep_and_drop.txt")
     if opt.year == "2017":
@@ -100,7 +100,7 @@ def main():
     if opt.year in ["UL2016_preVFPB","UL2016_preVFPC","UL2016_preVFPD","UL2016_preVFPE","UL2016_preVFPF"]:
       p = PostProcessor(opt.output, [opt.inputs], modules=[muonScaleRes2016a(),jetmetCorrector(),jmeCorrections(),VVV2016()], provenance=True,fwkJobReport=True, jsonInput=jsoninput)
 
-    if opt.year in ["UL2016_preVFPB","UL2016_preVFPC","UL2016_preVFPD","UL2016_preVFPE","UL2016_preVFPF"]:
+    if opt.year in ["UL2016F","UL2016G","UL2016H"]:
       p = PostProcessor(opt.output, [opt.inputs], modules=[muonScaleRes2016b(),jetmetCorrector(),jmeCorrections(),VVV2016()], provenance=True,fwkJobReport=True, jsonInput=jsoninput)
     
     if opt.year in ['UL2017B','UL2017C','UL2017D','UL2017E','UL2017F',]:


### PR DESCRIPTION
Update the run_condor.py, fix minimal flaws in https://github.com/gqlcms/XWWNano/blob/670b9d65b620465a3864bb2c5c43636cebabe1e7/test/run_condor.py#L98-L99 .

The influence is especially apparent for UL2016 data. 
For example, if opt.year is "UL2016_preVFPC", then the old code will have dataYear=2016, but runPeriod=_preVFPC.
(According to https://github.com/cms-nanoAOD/nanoAOD-tools/blob/c32f0556b61087c0bb0bd5b1f47a91a500b1c198/python/postprocessing/modules/jme/jetmetHelperRun2.py#L113-L124 ), 
finally use the jerTagsMC=UL2016 but not UL2016_preVFP, which is not as expected.
(According to https://github.com/StephenChao/XWWNano/blob/05ffdd06e985d4fa3754814628e53e086dc0ef42/others/for_jme/jetmetHelperRun2.py#L75-L82 )
